### PR TITLE
POST form fix on Aug 5, 2021

### DIFF
--- a/clock-in.py
+++ b/clock-in.py
@@ -108,6 +108,11 @@ class DaKa(object):
         new_info['jcqzrq'] = ""
         new_info['gwszdd'] = ""
         new_info['szgjcs'] = ""
+        
+        # 2021.08.05 Fix
+        new_info['23676ad88cb0953fa0e229b32e886f62'] = re.findall(r'"23676ad88cb0953fa0e229b32e886f62":\s*"([^\"]+)",', html)[0]
+        new_info['f6f259ba6791b79b64e0559fbe41050d'] = re.findall(r'"f6f259ba6791b79b64e0559fbe41050d":\s*"([^\"]+)",', html)[0]
+        
         self.info = new_info
         return new_info
 


### PR DESCRIPTION
The official website requires two extra items in the POST form, otherwise an error `{"e":1,"m":"请获取定位信息或者选取填写所在位置","d":{}}` is raised.

This fix parses the values from the original webpage and appends to the form.